### PR TITLE
Feat/#1 enter queue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-task'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -45,6 +44,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-orgjson', version: '0.11.2'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.2'
+
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
             "/ws/**",
             "/queue/**",
             "/seat.html",
-            "/reserve"
+            "/ticket/**"
     };
 
     @Bean

--- a/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
@@ -33,6 +33,10 @@ public class SecurityConfig {
             "/swagger-resources/**",
             "/webjars/**",
             "/error",
+            "/index.html",
+            "/ws",
+            "/ws/**",
+            "/queue/**"
     };
 
     @Bean

--- a/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/interlink/jwt/config/SecurityConfig.java
@@ -36,7 +36,9 @@ public class SecurityConfig {
             "/index.html",
             "/ws",
             "/ws/**",
-            "/queue/**"
+            "/queue/**",
+            "/seat.html",
+            "/reserve"
     };
 
     @Bean

--- a/src/main/java/com/example/interlink/macro/MacroApplication.java
+++ b/src/main/java/com/example/interlink/macro/MacroApplication.java
@@ -1,49 +1,49 @@
-package com.example.interlink.macro;
-
-import org.springframework.boot.*;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-
-@SpringBootApplication
-public class MacroApplication implements CommandLineRunner {
-
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final String targetUrl = "http://metal-load-balancer-300049590.ap-northeast-2.elb.amazonaws.com/";
-
-    @Override
-    public void run(String... args){
-        Executor executor = createExecutor(10);
-        int requestPerThread = 100;
-
-        for(int i=0; i<10; i++){
-            executor.execute(() -> sendRequests(requestPerThread));
-        }
-    }
-
-    private void sendRequests(int count){
-        for (int i=0; i< count; i++){
-            try{
-                String response = restTemplate.getForObject(targetUrl, String.class);
-                System.out.println("Response: " + response);
-            } catch (Exception e){
-                System.err.println("Requests failed: " + e.getMessage());
-            }
-
-        }
-    }
-
-    private Executor createExecutor(int threadCount){
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(threadCount);
-        executor.setMaxPoolSize(threadCount);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("MacroThread-");
-        executor.initialize();
-        return executor;
-    }
-
-}
+//package com.example.interlink.macro;
+//
+//import org.springframework.boot.*;
+//import org.springframework.boot.autoconfigure.SpringBootApplication;
+//import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+//import org.springframework.web.client.RestTemplate;
+//
+//import java.util.concurrent.ExecutionException;
+//import java.util.concurrent.Executor;
+//
+//@SpringBootApplication
+//public class MacroApplication implements CommandLineRunner {
+//
+//    private final RestTemplate restTemplate = new RestTemplate();
+//    private final String targetUrl = "http://metal-load-balancer-300049590.ap-northeast-2.elb.amazonaws.com/";
+//
+//    @Override
+//    public void run(String... args){
+//        Executor executor = createExecutor(10);
+//        int requestPerThread = 100;
+//
+//        for(int i=0; i<10; i++){
+//            executor.execute(() -> sendRequests(requestPerThread));
+//        }
+//    }
+//
+//    private void sendRequests(int count){
+//        for (int i=0; i< count; i++){
+//            try{
+//                String response = restTemplate.getForObject(targetUrl, String.class);
+//                System.out.println("Response: " + response);
+//            } catch (Exception e){
+//                System.err.println("Requests failed: " + e.getMessage());
+//            }
+//
+//        }
+//    }
+//
+//    private Executor createExecutor(int threadCount){
+//        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+//        executor.setCorePoolSize(threadCount);
+//        executor.setMaxPoolSize(threadCount);
+//        executor.setQueueCapacity(100);
+//        executor.setThreadNamePrefix("MacroThread-");
+//        executor.initialize();
+//        return executor;
+//    }
+//
+//}

--- a/src/main/java/com/example/interlink/queue/config/RedisConfig.java
+++ b/src/main/java/com/example/interlink/queue/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package com.example.interlink.queue.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}
+

--- a/src/main/java/com/example/interlink/queue/controller/QueueController.java
+++ b/src/main/java/com/example/interlink/queue/controller/QueueController.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/queue")
@@ -12,19 +15,44 @@ public class QueueController {
     private final QueueService queueService;
 
     @PostMapping("/enter")
-    public ResponseEntity<String> enterQueue(@RequestParam Long userId, @RequestParam int maxTickets) {
-        queueService.addToQueue(userId, maxTickets);  // 대기열에 사용자 추가
-        String positionMessage = queueService.getPositionMessage(userId, maxTickets);  // 대기열 메시지 생성
-        return ResponseEntity.ok(positionMessage);  // 응답 메시지 반환
+    public ResponseEntity<Map<String, Object>> enterQueue(@RequestParam Long userId, @RequestParam int maxTickets) {
+        queueService.addToQueue(userId, maxTickets); // 대기열에 사용자 추가
+        String positionMessage = queueService.getPositionMessage(userId, maxTickets); // 대기열 메시지 생성
+
+        // 사용자 상태 반환
+        Map<String, Object> response = new HashMap<>();
+        if (positionMessage.contains("대기열에 추가되었습니다")) {
+            response.put("status", "QUEUE");
+            response.put("url", "/seat.html?userId=" + userId);
+        } else if (positionMessage.contains("대기 상태로 전환되었습니다")) {
+            response.put("status", "WAITING");
+            response.put("position", extractPosition(positionMessage)); // 대기 위치
+        } else {
+            response.put("status", "UNKNOWN");
+            response.put("message", positionMessage);
+        }
+
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/state")
     public ResponseEntity<?> getQueueState() {
-        return ResponseEntity.ok(queueService.getQueueState("ticket:queue"));  // 대기열 상태 반환
+        return ResponseEntity.ok(queueService.getQueueState("ticket:queue")); // 대기열 상태 반환
     }
 
     @GetMapping("/waiting")
     public ResponseEntity<?> getWaitingState() {
-        return ResponseEntity.ok(queueService.getQueueState("ticket:waiting"));  // 대기 상태 반환
+        return ResponseEntity.ok(queueService.getQueueState("ticket:waiting")); // 대기 상태 반환
+    }
+
+    // 대기 위치 추출
+    private int extractPosition(String message) {
+        String[] splitMessage = message.split(" ");
+        for (String part : splitMessage) {
+            if (part.matches("\\d+")) { // 숫자인 부분만 추출
+                return Integer.parseInt(part);
+            }
+        }
+        return -1; // 추출 실패 시 -1 반환
     }
 }

--- a/src/main/java/com/example/interlink/queue/controller/QueueController.java
+++ b/src/main/java/com/example/interlink/queue/controller/QueueController.java
@@ -12,13 +12,19 @@ public class QueueController {
     private final QueueService queueService;
 
     @PostMapping("/enter")
-    public ResponseEntity<String> enterQueue(@RequestParam Long userId) {
-        queueService.addToQueue(userId);
-        return ResponseEntity.ok("대기열에 추가되었습니다. 사용자 ID: " + userId);
+    public ResponseEntity<String> enterQueue(@RequestParam Long userId, @RequestParam int maxTickets) {
+        queueService.addToQueue(userId, maxTickets);  // 대기열에 사용자 추가
+        String positionMessage = queueService.getPositionMessage(userId, maxTickets);  // 대기열 메시지 생성
+        return ResponseEntity.ok(positionMessage);  // 응답 메시지 반환
     }
 
     @GetMapping("/state")
     public ResponseEntity<?> getQueueState() {
-        return ResponseEntity.ok(queueService.getQueueState());
+        return ResponseEntity.ok(queueService.getQueueState("ticket:queue"));  // 대기열 상태 반환
+    }
+
+    @GetMapping("/waiting")
+    public ResponseEntity<?> getWaitingState() {
+        return ResponseEntity.ok(queueService.getQueueState("ticket:waiting"));  // 대기 상태 반환
     }
 }

--- a/src/main/java/com/example/interlink/queue/controller/QueueController.java
+++ b/src/main/java/com/example/interlink/queue/controller/QueueController.java
@@ -1,0 +1,24 @@
+package com.example.interlink.queue.controller;
+
+import com.example.interlink.queue.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/queue")
+public class QueueController {
+    private final QueueService queueService;
+
+    @PostMapping("/enter")
+    public ResponseEntity<String> enterQueue(@RequestParam Long userId) {
+        queueService.addToQueue(userId);
+        return ResponseEntity.ok("대기열에 추가되었습니다. 사용자 ID: " + userId);
+    }
+
+    @GetMapping("/state")
+    public ResponseEntity<?> getQueueState() {
+        return ResponseEntity.ok(queueService.getQueueState());
+    }
+}

--- a/src/main/java/com/example/interlink/queue/service/QueueService.java
+++ b/src/main/java/com/example/interlink/queue/service/QueueService.java
@@ -18,48 +18,59 @@ public class QueueService {
 
     private static final String QUEUE_KEY = "ticket:queue";
     private static final String USER_INFO_KEY_PREFIX = "ticket:user:";
+    private int maxTickets = 0;
 
-    public void addToQueue(Long userId) {
-        List<Object> queue = redisTemplate.opsForList().range(QUEUE_KEY, 0, -1);
 
-        // 중복 추가 방지
+    public void addToQueue(Long userId, int maxTickets) {
+        List<Object> queue = getQueueState(QUEUE_KEY);
+        List<Object> waiting = getQueueState("ticket:waiting");
+
         if (queue != null && queue.contains(userId.toString())) {
             System.out.println("이미 대기열에 추가된 사용자: " + userId);
             return;
         }
+        if (waiting != null && waiting.contains(userId.toString())) {
+            System.out.println("이미 대기 상태에 있는 사용자: " + userId);
+            return;
+        }
 
-        // 대기열에 사용자 추가
-        redisTemplate.opsForList().rightPush(QUEUE_KEY, userId.toString());
+        if (queue != null && queue.size() < maxTickets) {
+            redisTemplate.opsForList().rightPush(QUEUE_KEY, userId.toString());
+            System.out.println("사용자 추가됨 (대기열): " + userId);
+        } else {
+            redisTemplate.opsForList().rightPush("ticket:waiting", userId.toString());
+            System.out.println("사용자 추가됨 (대기 상태): " + userId);
+        }
 
-        // 사용자 정보 저장 (대기 시작 시간과 상태)
-        Map<String, Object> userInfo = new HashMap<>();
-        userInfo.put("status", "WAITING"); // 상태: 대기 중
-        userInfo.put("joinedAt", Instant.now().toString()); // 대기 시작 시간
-        redisTemplate.opsForHash().putAll(USER_INFO_KEY_PREFIX + userId, userInfo);
+        String userKey = getUserKey(userId);
+        if (!redisTemplate.hasKey(userKey)) {
+            Map<String, Object> userInfo = new HashMap<>();
+            userInfo.put("status", queue != null && queue.size() < maxTickets ? "QUEUE" : "WAITING");
+            userInfo.put("joinedAt", Instant.now().toString());
+            redisTemplate.opsForHash().putAll(userKey, userInfo);
+        }
 
-        broadcastQueueState();
+        broadcastQueueState(maxTickets);
     }
 
     public Long removeFromQueue() {
         String userId = (String) redisTemplate.opsForList().leftPop(QUEUE_KEY);
 
         if (userId != null) {
-            // 상태 변경: 처리 중
-            redisTemplate.opsForHash().put(USER_INFO_KEY_PREFIX + userId, "status", "PROCESSING");
+            redisTemplate.opsForHash().put(getUserKey(Long.parseLong(userId)), "status", "PROCESSING");
         }
 
-        broadcastQueueState();
+        broadcastQueueState(maxTickets);
         return userId != null ? Long.parseLong(userId) : null;
     }
 
-    public List<Object> getQueueState() {
-        return redisTemplate.opsForList().range(QUEUE_KEY, 0, -1);
+    public List<Object> getQueueState(String key) {
+        return redisTemplate.opsForList().range(key, 0, -1);
     }
 
     public Map<String, Object> getUserInfo(Long userId) {
-        Map<Object, Object> rawUserInfo = redisTemplate.opsForHash().entries(USER_INFO_KEY_PREFIX + userId);
+        Map<Object, Object> rawUserInfo = redisTemplate.opsForHash().entries(getUserKey(userId));
 
-        // Object -> String으로 변환
         Map<String, Object> userInfo = new HashMap<>();
         for (Map.Entry<Object, Object> entry : rawUserInfo.entrySet()) {
             userInfo.put(entry.getKey().toString(), entry.getValue());
@@ -68,19 +79,36 @@ public class QueueService {
         return userInfo;
     }
 
-    private void broadcastQueueState() {
-        List<Object> queue = getQueueState();
-        Map<Long, Map<String, Object>> userDetails = new HashMap<>();
+    private void broadcastQueueState(int maxTickets) {
+        List<Object> queue = getQueueState(QUEUE_KEY);
+        List<Object> waiting = getQueueState("ticket:waiting");
 
-        // 대기열 사용자들의 상세 정보 추가
-        if (queue != null) {
-            for (Object userId : queue) {
-                Long id = Long.parseLong(userId.toString());
-                userDetails.put(id, getUserInfo(id));
-            }
+        Map<String, Object> queueDetails = new HashMap<>();
+        queueDetails.put("queue", queue);
+        queueDetails.put("waiting", waiting);
+        queueDetails.put("maxTickets", maxTickets);
+
+        messagingTemplate.convertAndSend("/topic/queue/1", queueDetails);
+        System.out.println("대기열 브로드캐스트 상태: " + queueDetails);
+    }
+
+    private String getUserKey(Long userId) {
+        return USER_INFO_KEY_PREFIX + userId;
+    }
+
+    public String getPositionMessage(Long userId, int maxTickets) {
+        List<Object> queue = getQueueState(QUEUE_KEY);
+        List<Object> waiting = getQueueState("ticket:waiting");
+
+        int positionInQueue = queue.indexOf(userId.toString());
+        int positionInWaiting = waiting.indexOf(userId.toString());
+
+        if (positionInQueue >= 0) {
+            return String.format("대기열에 추가되었습니다. 현재 순서: %d", positionInQueue + 1);
+        } else if (positionInWaiting >= 0) {
+            return String.format("대기 상태로 전환되었습니다. 내 앞에 %d명 남았습니다.", positionInWaiting);
+        } else {
+            return "대기열 또는 대기 상태에 추가되지 않았습니다.";
         }
-
-        messagingTemplate.convertAndSend("/topic/queue/1", userDetails); // WebSocket 브로드캐스트
-        System.out.println("대기열 브로드캐스트 상태: " + userDetails);
     }
 }

--- a/src/main/java/com/example/interlink/queue/service/QueueService.java
+++ b/src/main/java/com/example/interlink/queue/service/QueueService.java
@@ -17,71 +17,99 @@ public class QueueService {
     private final SimpMessagingTemplate messagingTemplate;
 
     private static final String QUEUE_KEY = "ticket:queue";
+    private static final String WAITING_KEY = "ticket:waiting";
     private static final String USER_INFO_KEY_PREFIX = "ticket:user:";
     private int maxTickets = 0;
 
-
+    // 사용자 추가
     public void addToQueue(Long userId, int maxTickets) {
+        System.out.println("addToQueue 호출됨: " + userId);
+
         List<Object> queue = getQueueState(QUEUE_KEY);
-        List<Object> waiting = getQueueState("ticket:waiting");
+        List<Object> waiting = getQueueState(WAITING_KEY);
 
-        if (queue != null && queue.contains(userId.toString())) {
-            System.out.println("이미 대기열에 추가된 사용자: " + userId);
-            return;
-        }
-        if (waiting != null && waiting.contains(userId.toString())) {
-            System.out.println("이미 대기 상태에 있는 사용자: " + userId);
+        if (queue.contains(userId.toString()) || waiting.contains(userId.toString())) {
+            System.out.println("이미 대기열 또는 대기 상태에 있는 사용자: " + userId);
             return;
         }
 
-        if (queue != null && queue.size() < maxTickets) {
+        if (queue.size() < maxTickets) {
             redisTemplate.opsForList().rightPush(QUEUE_KEY, userId.toString());
-            System.out.println("사용자 추가됨 (대기열): " + userId);
-        } else {
-            redisTemplate.opsForList().rightPush("ticket:waiting", userId.toString());
-            System.out.println("사용자 추가됨 (대기 상태): " + userId);
-        }
+            updateUserInfo(userId, "QUEUE");
+            System.out.println("QUEUE에 추가됨: " + userId);
 
-        String userKey = getUserKey(userId);
-        if (!redisTemplate.hasKey(userKey)) {
-            Map<String, Object> userInfo = new HashMap<>();
-            userInfo.put("status", queue != null && queue.size() < maxTickets ? "QUEUE" : "WAITING");
-            userInfo.put("joinedAt", Instant.now().toString());
-            redisTemplate.opsForHash().putAll(userKey, userInfo);
+            // 바로 좌석 선택 페이지로 이동
+            sendRedirectMessage(userId);
+        } else {
+            redisTemplate.opsForList().rightPush(WAITING_KEY, userId.toString());
+            updateUserInfo(userId, "WAITING");
+            System.out.println("WAITING에 추가됨: " + userId);
         }
 
         broadcastQueueState(maxTickets);
     }
 
-    public Long removeFromQueue() {
+    // 사용자 제거
+    public void removeFromQueue() {
+        System.out.println("removeFromQueue 호출됨");
+
+        // 대기열에서 사용자 제거
         String userId = (String) redisTemplate.opsForList().leftPop(QUEUE_KEY);
 
         if (userId != null) {
-            redisTemplate.opsForHash().put(getUserKey(Long.parseLong(userId)), "status", "PROCESSING");
-        }
+            updateUserInfo(Long.parseLong(userId), "PROCESSING");
 
-        broadcastQueueState(maxTickets);
-        return userId != null ? Long.parseLong(userId) : null;
+            String nextUserId = (String) redisTemplate.opsForList().leftPop(WAITING_KEY);
+            if (nextUserId != null) {
+                redisTemplate.opsForList().rightPush(QUEUE_KEY, nextUserId);
+                updateUserInfo(Long.parseLong(nextUserId), "QUEUE");
+
+                // 리다이렉트 명령 전송
+                sendRedirectMessage(Long.parseLong(nextUserId));
+            }
+
+            broadcastQueueState(maxTickets);
+        }
     }
 
+    // 리다이렉트 메시지 전송 로직 분리
+    private void sendRedirectMessage(Long userId) {
+        messagingTemplate.convertAndSend(
+                "/topic/user/" + userId,
+                Map.of(
+                        "action", "redirect",
+                        "url", "/seat.html?userId=" + userId
+                )
+        );
+        System.out.println("Redirect message sent to /topic/user/" + userId);
+    }
+
+    // 대기열 상태 반환
     public List<Object> getQueueState(String key) {
         return redisTemplate.opsForList().range(key, 0, -1);
     }
 
+    // 사용자 정보 반환
     public Map<String, Object> getUserInfo(Long userId) {
         Map<Object, Object> rawUserInfo = redisTemplate.opsForHash().entries(getUserKey(userId));
-
         Map<String, Object> userInfo = new HashMap<>();
-        for (Map.Entry<Object, Object> entry : rawUserInfo.entrySet()) {
-            userInfo.put(entry.getKey().toString(), entry.getValue());
-        }
-
+        rawUserInfo.forEach((key, value) -> userInfo.put(key.toString(), value));
         return userInfo;
     }
 
-    private void broadcastQueueState(int maxTickets) {
+    // 사용자 상태 업데이트
+    private void updateUserInfo(Long userId, String status) {
+        String userKey = getUserKey(userId);
+        Map<String, Object> userInfo = new HashMap<>();
+        userInfo.put("status", status);
+        userInfo.put("joinedAt", Instant.now().toString());
+        redisTemplate.opsForHash().putAll(userKey, userInfo);
+    }
+
+    // 대기열 상태 브로드캐스트
+    public void broadcastQueueState(int maxTickets) {
         List<Object> queue = getQueueState(QUEUE_KEY);
-        List<Object> waiting = getQueueState("ticket:waiting");
+        List<Object> waiting = getQueueState(WAITING_KEY);
 
         Map<String, Object> queueDetails = new HashMap<>();
         queueDetails.put("queue", queue);
@@ -89,16 +117,13 @@ public class QueueService {
         queueDetails.put("maxTickets", maxTickets);
 
         messagingTemplate.convertAndSend("/topic/queue/1", queueDetails);
-        System.out.println("대기열 브로드캐스트 상태: " + queueDetails);
+        System.out.println("대기열 상태 브로드캐스트: " + queueDetails);
     }
 
-    private String getUserKey(Long userId) {
-        return USER_INFO_KEY_PREFIX + userId;
-    }
-
+    // 사용자 대기 메시지
     public String getPositionMessage(Long userId, int maxTickets) {
         List<Object> queue = getQueueState(QUEUE_KEY);
-        List<Object> waiting = getQueueState("ticket:waiting");
+        List<Object> waiting = getQueueState(WAITING_KEY);
 
         int positionInQueue = queue.indexOf(userId.toString());
         int positionInWaiting = waiting.indexOf(userId.toString());
@@ -110,5 +135,9 @@ public class QueueService {
         } else {
             return "대기열 또는 대기 상태에 추가되지 않았습니다.";
         }
+    }
+
+    private String getUserKey(Long userId) {
+        return USER_INFO_KEY_PREFIX + userId;
     }
 }

--- a/src/main/java/com/example/interlink/queue/service/QueueService.java
+++ b/src/main/java/com/example/interlink/queue/service/QueueService.java
@@ -1,0 +1,86 @@
+package com.example.interlink.queue.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private static final String QUEUE_KEY = "ticket:queue";
+    private static final String USER_INFO_KEY_PREFIX = "ticket:user:";
+
+    public void addToQueue(Long userId) {
+        List<Object> queue = redisTemplate.opsForList().range(QUEUE_KEY, 0, -1);
+
+        // 중복 추가 방지
+        if (queue != null && queue.contains(userId.toString())) {
+            System.out.println("이미 대기열에 추가된 사용자: " + userId);
+            return;
+        }
+
+        // 대기열에 사용자 추가
+        redisTemplate.opsForList().rightPush(QUEUE_KEY, userId.toString());
+
+        // 사용자 정보 저장 (대기 시작 시간과 상태)
+        Map<String, Object> userInfo = new HashMap<>();
+        userInfo.put("status", "WAITING"); // 상태: 대기 중
+        userInfo.put("joinedAt", Instant.now().toString()); // 대기 시작 시간
+        redisTemplate.opsForHash().putAll(USER_INFO_KEY_PREFIX + userId, userInfo);
+
+        broadcastQueueState();
+    }
+
+    public Long removeFromQueue() {
+        String userId = (String) redisTemplate.opsForList().leftPop(QUEUE_KEY);
+
+        if (userId != null) {
+            // 상태 변경: 처리 중
+            redisTemplate.opsForHash().put(USER_INFO_KEY_PREFIX + userId, "status", "PROCESSING");
+        }
+
+        broadcastQueueState();
+        return userId != null ? Long.parseLong(userId) : null;
+    }
+
+    public List<Object> getQueueState() {
+        return redisTemplate.opsForList().range(QUEUE_KEY, 0, -1);
+    }
+
+    public Map<String, Object> getUserInfo(Long userId) {
+        Map<Object, Object> rawUserInfo = redisTemplate.opsForHash().entries(USER_INFO_KEY_PREFIX + userId);
+
+        // Object -> String으로 변환
+        Map<String, Object> userInfo = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : rawUserInfo.entrySet()) {
+            userInfo.put(entry.getKey().toString(), entry.getValue());
+        }
+
+        return userInfo;
+    }
+
+    private void broadcastQueueState() {
+        List<Object> queue = getQueueState();
+        Map<Long, Map<String, Object>> userDetails = new HashMap<>();
+
+        // 대기열 사용자들의 상세 정보 추가
+        if (queue != null) {
+            for (Object userId : queue) {
+                Long id = Long.parseLong(userId.toString());
+                userDetails.put(id, getUserInfo(id));
+            }
+        }
+
+        messagingTemplate.convertAndSend("/topic/queue/1", userDetails); // WebSocket 브로드캐스트
+        System.out.println("대기열 브로드캐스트 상태: " + userDetails);
+    }
+}

--- a/src/main/java/com/example/interlink/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/example/interlink/websocket/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.example.interlink.websocket.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
+  data:
+    redis:
+      port: 6379
+      host: localhost
+
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -35,28 +35,38 @@
 <h2>대기열 상태</h2>
 <ul id="queue-list"></ul>
 
+<h2>대기 상태</h2>
+<ul id="waiting-list"></ul>
+
 <script>
   let stompClient;
 
+  // WebSocket 연결 및 대기열 구독
   function connectWebSocket() {
     const socket = new SockJS('http://localhost:8080/ws');
-    const stompClient = Stomp.over(socket);
+    stompClient = Stomp.over(socket);
 
     stompClient.connect({}, () => {
       console.log('WebSocket 연결 성공');
       stompClient.subscribe('/topic/queue/1', (message) => {
         console.log('수신 메시지:', message.body); // 메시지 디버깅
-        const queue = JSON.parse(message.body);
-        updateQueue(queue);
+        const queueDetails = JSON.parse(message.body);
+        updateQueue(queueDetails);  // 대기열 및 대기 상태 업데이트
       });
     }, (error) => {
       console.error('WebSocket 연결 실패:', error);
     });
   }
+
+  // 대기열에 사용자 추가
   function enterQueue() {
     const userId = document.getElementById('userId').value;
+    if (!userId) {
+      alert('사용자 ID를 입력해주세요.');
+      return;
+    }
 
-    fetch(`http://localhost:8080/queue/enter?userId=${userId}`, {
+    fetch(`http://localhost:8080/queue/enter?userId=${userId}&maxTickets=3`, {
       method: 'POST',
     })
             .then(response => response.text())
@@ -64,25 +74,49 @@
             .catch(err => console.error(err));
   }
 
-  function updateQueue(queue) {
+  // 대기열 및 대기 상태 업데이트
+  function updateQueue(queueDetails) {
     const queueList = document.getElementById('queue-list');
-    queueList.innerHTML = ''; // 기존 리스트 초기화
+    const waitingList = document.getElementById('waiting-list');
+    const userId = document.getElementById('userId').value;  // 현재 사용자 ID
 
-    Object.entries(queue).forEach(([userId, details], index) => {
+    queueList.innerHTML = '';  // 대기열 초기화
+    waitingList.innerHTML = '';  // 대기 상태 초기화
+
+    const queue = queueDetails.queue || [];
+    const waiting = queueDetails.waiting || [];
+    const maxTickets = queueDetails.maxTickets || 0;
+
+    // 대기열 표시
+    queue.forEach((userIdInQueue, index) => {
       const listItem = document.createElement('li');
-
-      const status = details.status || "UNKNOWN";
-      const joinedAt = details.joinedAt || "N/A";
-
-      listItem.textContent = `${index + 1}. 사용자 ID: ${userId}, 상태: ${status}, 대기 시작: ${joinedAt}`;
+      listItem.textContent = `${index + 1}. 사용자 ID: ${userIdInQueue}`;
       queueList.appendChild(listItem);
     });
 
-    console.log('대기열 상태 업데이트:', queue);
+    // 대기 상태 표시
+    waiting.forEach((userIdInWaiting, index) => {
+      const listItem = document.createElement('li');
+      listItem.textContent = `${index + 1}. 사용자 ID: ${userIdInWaiting}, 대기 순서: ${index + 1}`;
+      waitingList.appendChild(listItem);
+    });
+
+    // 내 대기 상태 표시
+    const positionInQueue = queue.indexOf(userId);
+    const positionInWaiting = waiting.indexOf(userId);
+
+    if (positionInQueue >= 0) {
+      console.log(`대기열에 있습니다. 현재 순서: ${positionInQueue + 1}`);
+    } else if (positionInWaiting >= 0) {
+      console.log(`대기 중입니다. 내 앞에 ${positionInWaiting}명 남았습니다.`);
+    } else {
+      console.log("대기열 또는 대기 상태에 없습니다.");
+    }
   }
 
-
+  // WebSocket 연결
   connectWebSocket();
 </script>
+
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -25,6 +25,18 @@
       border: 1px solid #007bff;
       margin: 5px;
       background-color: #f4f4f4;
+      position: relative;
+    }
+    .waiting-badge {
+      position: absolute;
+      top: 50%;
+      left: 10px;
+      transform: translateY(-50%);
+      background-color: #007bff;
+      color: white;
+      padding: 5px 10px;
+      border-radius: 20px;
+      font-size: 12px;
     }
   </style>
 </head>
@@ -32,35 +44,34 @@
 <h1>실시간 대기열</h1>
 <input type="number" id="userId" placeholder="사용자 ID 입력">
 <button onclick="enterQueue()">대기열 추가</button>
-<h2>대기열 상태</h2>
-<ul id="queue-list"></ul>
-
 <h2>대기 상태</h2>
 <ul id="waiting-list"></ul>
 
 <script>
   let stompClient;
+  let userId;
 
-  // WebSocket 연결 및 대기열 구독
   function connectWebSocket() {
     const socket = new SockJS('http://localhost:8080/ws');
     stompClient = Stomp.over(socket);
 
     stompClient.connect({}, () => {
       console.log('WebSocket 연결 성공');
+
+      // 대기열 상태 구독
       stompClient.subscribe('/topic/queue/1', (message) => {
-        console.log('수신 메시지:', message.body); // 메시지 디버깅
         const queueDetails = JSON.parse(message.body);
-        updateQueue(queueDetails);  // 대기열 및 대기 상태 업데이트
+        updateWaiting(queueDetails.waiting || []);
       });
     }, (error) => {
       console.error('WebSocket 연결 실패:', error);
     });
   }
 
-  // 대기열에 사용자 추가
   function enterQueue() {
-    const userId = document.getElementById('userId').value;
+    const userIdInput = document.getElementById('userId');
+    const userId = userIdInput.value;
+
     if (!userId) {
       alert('사용자 ID를 입력해주세요.');
       return;
@@ -69,54 +80,68 @@
     fetch(`http://localhost:8080/queue/enter?userId=${userId}&maxTickets=3`, {
       method: 'POST',
     })
-            .then(response => response.text())
-            .then(result => console.log(result))
-            .catch(err => console.error(err));
+            .then(response => response.json())
+            .then(result => {
+              console.log('서버 응답:', result);
+
+              // 사용자 상태 확인
+              if (result.status === 'QUEUE') {
+                // 대기열에 추가된 경우 좌석 선택 페이지로 이동
+                console.log(`Redirecting to seat.html with userId: ${userId}`);
+                window.location.href = `/seat.html?userId=${userId}`;
+              } else if (result.status === 'WAITING') {
+                // 대기 상태인 경우 대기 목록 업데이트
+                console.log(`대기 상태입니다. 내 앞에 ${result.position+1}명이 있습니다.`);
+                updateWaiting(result.waitingList || []);
+              } else {
+                console.error('예기치 못한 상태:', result);
+              }
+            })
+            .catch(err => {
+              console.error('대기열 추가 중 오류:', err);
+              alert('대기열 추가 중 오류가 발생했습니다.');
+            });
   }
 
-  // 대기열 및 대기 상태 업데이트
-  function updateQueue(queueDetails) {
-    const queueList = document.getElementById('queue-list');
-    const waitingList = document.getElementById('waiting-list');
-    const userId = document.getElementById('userId').value;  // 현재 사용자 ID
+  function updateWaiting(waitingList) {
+    const waitingContainer = document.getElementById('waiting-list');
+    const existingItems = new Set();
 
-    queueList.innerHTML = '';  // 대기열 초기화
-    waitingList.innerHTML = '';  // 대기 상태 초기화
-
-    const queue = queueDetails.queue || [];
-    const waiting = queueDetails.waiting || [];
-    const maxTickets = queueDetails.maxTickets || 0;
-
-    // 대기열 표시
-    queue.forEach((userIdInQueue, index) => {
-      const listItem = document.createElement('li');
-      listItem.textContent = `${index + 1}. 사용자 ID: ${userIdInQueue}`;
-      queueList.appendChild(listItem);
+    waitingContainer.querySelectorAll('li').forEach((item) => {
+      const userId = item.dataset.userId;
+      existingItems.add(userId);
     });
 
-    // 대기 상태 표시
-    waiting.forEach((userIdInWaiting, index) => {
-      const listItem = document.createElement('li');
-      listItem.textContent = `${index + 1}. 사용자 ID: ${userIdInWaiting}, 대기 순서: ${index + 1}`;
-      waitingList.appendChild(listItem);
+    waitingList.forEach((userId, index) => {
+      if (!existingItems.has(userId)) {
+        const listItem = document.createElement('li');
+        const badge = document.createElement('span');
+
+        badge.classList.add('waiting-badge');
+        badge.textContent = `대기 ${index + 1}번`;
+
+        listItem.textContent = `사용자 ID: ${userId}`;
+        listItem.dataset.userId = userId; // 사용자 ID를 dataset에 저장
+        listItem.appendChild(badge);
+        waitingContainer.appendChild(listItem);
+      }
     });
 
-    // 내 대기 상태 표시
-    const positionInQueue = queue.indexOf(userId);
-    const positionInWaiting = waiting.indexOf(userId);
-
-    if (positionInQueue >= 0) {
-      console.log(`대기열에 있습니다. 현재 순서: ${positionInQueue + 1}`);
-    } else if (positionInWaiting >= 0) {
-      console.log(`대기 중입니다. 내 앞에 ${positionInWaiting}명 남았습니다.`);
-    } else {
-      console.log("대기열 또는 대기 상태에 없습니다.");
-    }
+    // 기존 대기 상태에서 없어진 사용자 제거
+    waitingContainer.querySelectorAll('li').forEach((item) => {
+      const userId = item.dataset.userId;
+      if (!waitingList.includes(userId)) {
+        item.remove();
+      }
+    });
   }
 
-  // WebSocket 연결
-  connectWebSocket();
+
+
+  // 페이지 로드 시 WebSocket 연결
+  document.addEventListener('DOMContentLoaded', () => {
+    connectWebSocket();
+  });
 </script>
-
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -16,27 +16,10 @@
       padding: 10px;
       margin: 10px;
     }
-    ul {
-      list-style-type: none;
-      padding: 0;
-    }
-    li {
-      padding: 10px;
-      border: 1px solid #007bff;
-      margin: 5px;
-      background-color: #f4f4f4;
-      position: relative;
-    }
-    .waiting-badge {
-      position: absolute;
-      top: 50%;
-      left: 10px;
-      transform: translateY(-50%);
-      background-color: #007bff;
-      color: white;
-      padding: 5px 10px;
-      border-radius: 20px;
-      font-size: 12px;
+    #current-user-status {
+      font-size: 1.5rem;
+      margin-top: 20px;
+      color: #007bff;
     }
   </style>
 </head>
@@ -44,12 +27,50 @@
 <h1>실시간 대기열</h1>
 <input type="number" id="userId" placeholder="사용자 ID 입력">
 <button onclick="enterQueue()">대기열 추가</button>
-<h2>대기 상태</h2>
-<ul id="waiting-list"></ul>
+<p id="current-user-status">대기 상태를 확인 중입니다...</p>
 
 <script>
   let stompClient;
-  let userId;
+  let currentUserId = null; // 현재 사용자 ID 저장
+
+  function enterQueue() {
+    const userIdInput = document.getElementById('userId');
+    const userId = userIdInput.value;
+
+    if (!userId) {
+      alert('사용자 ID를 입력해주세요.');
+      return;
+    }
+
+    currentUserId = userId; // 현재 사용자 ID 저장
+
+    fetch(`http://localhost:8080/queue/enter?userId=${userId}&maxTickets=3`, {
+      method: 'POST',
+    })
+            .then(response => response.json())
+            .then(result => {
+              console.log('서버 응답:', result);
+
+              if (result.status === 'QUEUE') {
+                console.log(`Redirecting to seat.html with userId: ${userId}`);
+                window.location.href = `/seat.html?userId=${userId}`;
+              } else if (result.status === 'WAITING') {
+                console.log(`대기 상태입니다. 내 앞에 ${result.position + 1}명이 있습니다.`);
+                updateWaitingStatus(result.position + 1);
+              } else {
+                console.error('예기치 못한 상태:', result);
+              }
+            })
+            .catch(err => {
+              console.error('대기열 추가 중 오류:', err);
+              alert('대기열 추가 중 오류가 발생했습니다.');
+            });
+  }
+
+  function updateWaitingStatus(position) {
+    const currentUserDisplay = document.getElementById('current-user-status');
+    currentUserDisplay.textContent = `현재 대기열에서 내 앞에 ${position}명이 있습니다.`;
+  }
 
   function connectWebSocket() {
     const socket = new SockJS('http://localhost:8080/ws');
@@ -61,82 +82,23 @@
       // 대기열 상태 구독
       stompClient.subscribe('/topic/queue/1', (message) => {
         const queueDetails = JSON.parse(message.body);
-        updateWaiting(queueDetails.waiting || []);
+
+        // 현재 사용자 위치를 확인하고 갱신
+        const position = queueDetails.waiting.indexOf(currentUserId);
+        if (position >= 0) {
+          updateWaitingStatus(position);
+        }
+
+        // 현재 사용자가 QUEUE로 들어간 경우 리다이렉트 처리
+        if (queueDetails.queue.includes(currentUserId)) {
+          console.log(`Redirecting to seat.html for userId: ${currentUserId}`);
+          window.location.href = `/seat.html?userId=${currentUserId}`;
+        }
       });
     }, (error) => {
       console.error('WebSocket 연결 실패:', error);
     });
   }
-
-  function enterQueue() {
-    const userIdInput = document.getElementById('userId');
-    const userId = userIdInput.value;
-
-    if (!userId) {
-      alert('사용자 ID를 입력해주세요.');
-      return;
-    }
-
-    fetch(`http://localhost:8080/queue/enter?userId=${userId}&maxTickets=3`, {
-      method: 'POST',
-    })
-            .then(response => response.json())
-            .then(result => {
-              console.log('서버 응답:', result);
-
-              // 사용자 상태 확인
-              if (result.status === 'QUEUE') {
-                // 대기열에 추가된 경우 좌석 선택 페이지로 이동
-                console.log(`Redirecting to seat.html with userId: ${userId}`);
-                window.location.href = `/seat.html?userId=${userId}`;
-              } else if (result.status === 'WAITING') {
-                // 대기 상태인 경우 대기 목록 업데이트
-                console.log(`대기 상태입니다. 내 앞에 ${result.position+1}명이 있습니다.`);
-                updateWaiting(result.waitingList || []);
-              } else {
-                console.error('예기치 못한 상태:', result);
-              }
-            })
-            .catch(err => {
-              console.error('대기열 추가 중 오류:', err);
-              alert('대기열 추가 중 오류가 발생했습니다.');
-            });
-  }
-
-  function updateWaiting(waitingList) {
-    const waitingContainer = document.getElementById('waiting-list');
-    const existingItems = new Set();
-
-    waitingContainer.querySelectorAll('li').forEach((item) => {
-      const userId = item.dataset.userId;
-      existingItems.add(userId);
-    });
-
-    waitingList.forEach((userId, index) => {
-      if (!existingItems.has(userId)) {
-        const listItem = document.createElement('li');
-        const badge = document.createElement('span');
-
-        badge.classList.add('waiting-badge');
-        badge.textContent = `대기 ${index + 1}번`;
-
-        listItem.textContent = `사용자 ID: ${userId}`;
-        listItem.dataset.userId = userId; // 사용자 ID를 dataset에 저장
-        listItem.appendChild(badge);
-        waitingContainer.appendChild(listItem);
-      }
-    });
-
-    // 기존 대기 상태에서 없어진 사용자 제거
-    waitingContainer.querySelectorAll('li').forEach((item) => {
-      const userId = item.dataset.userId;
-      if (!waitingList.includes(userId)) {
-        item.remove();
-      }
-    });
-  }
-
-
 
   // 페이지 로드 시 WebSocket 연결
   document.addEventListener('DOMContentLoaded', () => {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Queue Monitor</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      padding: 20px;
+    }
+    input, button {
+      padding: 10px;
+      margin: 10px;
+    }
+    ul {
+      list-style-type: none;
+      padding: 0;
+    }
+    li {
+      padding: 10px;
+      border: 1px solid #007bff;
+      margin: 5px;
+      background-color: #f4f4f4;
+    }
+  </style>
+</head>
+<body>
+<h1>실시간 대기열</h1>
+<input type="number" id="userId" placeholder="사용자 ID 입력">
+<button onclick="enterQueue()">대기열 추가</button>
+<h2>대기열 상태</h2>
+<ul id="queue-list"></ul>
+
+<script>
+  let stompClient;
+
+  function connectWebSocket() {
+    const socket = new SockJS('http://localhost:8080/ws');
+    const stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, () => {
+      console.log('WebSocket 연결 성공');
+      stompClient.subscribe('/topic/queue/1', (message) => {
+        console.log('수신 메시지:', message.body); // 메시지 디버깅
+        const queue = JSON.parse(message.body);
+        updateQueue(queue);
+      });
+    }, (error) => {
+      console.error('WebSocket 연결 실패:', error);
+    });
+  }
+  function enterQueue() {
+    const userId = document.getElementById('userId').value;
+
+    fetch(`http://localhost:8080/queue/enter?userId=${userId}`, {
+      method: 'POST',
+    })
+            .then(response => response.text())
+            .then(result => console.log(result))
+            .catch(err => console.error(err));
+  }
+
+  function updateQueue(queue) {
+    const queueList = document.getElementById('queue-list');
+    queueList.innerHTML = ''; // 기존 리스트 초기화
+
+    Object.entries(queue).forEach(([userId, details], index) => {
+      const listItem = document.createElement('li');
+
+      const status = details.status || "UNKNOWN";
+      const joinedAt = details.joinedAt || "N/A";
+
+      listItem.textContent = `${index + 1}. 사용자 ID: ${userId}, 상태: ${status}, 대기 시작: ${joinedAt}`;
+      queueList.appendChild(listItem);
+    });
+
+    console.log('대기열 상태 업데이트:', queue);
+  }
+
+
+  connectWebSocket();
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -20,6 +20,7 @@
       font-size: 1.5rem;
       margin-top: 20px;
       color: #007bff;
+      transition: all 0.3s ease; /* 부드러운 애니메이션 */
     }
   </style>
 </head>
@@ -32,10 +33,12 @@
 <script>
   let stompClient;
   let currentUserId = null; // 현재 사용자 ID 저장
+  let lastPosition = null; // 이전 위치 저장 (깜빡임 방지)
 
+  // 대기열에 사용자 추가
   function enterQueue() {
     const userIdInput = document.getElementById('userId');
-    const userId = userIdInput.value;
+    const userId = userIdInput.value.trim();
 
     if (!userId) {
       alert('사용자 ID를 입력해주세요.');
@@ -52,11 +55,11 @@
               console.log('서버 응답:', result);
 
               if (result.status === 'QUEUE') {
-                console.log(`Redirecting to seat.html with userId: ${userId}`);
+                // QUEUE 상태라면 바로 좌석 선택 페이지로 이동
                 window.location.href = `/seat.html?userId=${userId}`;
               } else if (result.status === 'WAITING') {
-                console.log(`대기 상태입니다. 내 앞에 ${result.position + 1}명이 있습니다.`);
-                updateWaitingStatus(result.position + 1);
+                // WAITING 상태라면 내 앞에 몇 명인지 표시
+                updateWaitingStatus(result.position);
               } else {
                 console.error('예기치 못한 상태:', result);
               }
@@ -67,11 +70,24 @@
             });
   }
 
+  // 대기 상태 업데이트
   function updateWaitingStatus(position) {
     const currentUserDisplay = document.getElementById('current-user-status');
-    currentUserDisplay.textContent = `현재 대기열에서 내 앞에 ${position}명이 있습니다.`;
+
+    // 이전 위치와 동일하면 업데이트하지 않음 (깜빡임 방지)
+    if (lastPosition === position) return;
+
+    lastPosition = position; // 현재 위치 저장
+
+    // 상태 업데이트
+    if (position === -1) {
+      currentUserDisplay.textContent = '현재 대기 상태가 아닙니다.';
+    } else {
+      currentUserDisplay.textContent = `현재 대기열에서 내 앞에 ${position}명이 있습니다.`;
+    }
   }
 
+  // WebSocket 연결
   function connectWebSocket() {
     const socket = new SockJS('http://localhost:8080/ws');
     stompClient = Stomp.over(socket);
@@ -83,14 +99,16 @@
       stompClient.subscribe('/topic/queue/1', (message) => {
         const queueDetails = JSON.parse(message.body);
 
+        console.log('받은 대기열 상태:', queueDetails);
+
         // 현재 사용자 위치를 확인하고 갱신
-        const position = queueDetails.waiting.indexOf(currentUserId);
-        if (position >= 0) {
+        if (queueDetails.waiting && queueDetails.waiting.includes(currentUserId)) {
+          const position = queueDetails.waiting.indexOf(currentUserId);
           updateWaitingStatus(position);
         }
 
         // 현재 사용자가 QUEUE로 들어간 경우 리다이렉트 처리
-        if (queueDetails.queue.includes(currentUserId)) {
+        if (queueDetails.queue && queueDetails.queue.includes(currentUserId)) {
           console.log(`Redirecting to seat.html for userId: ${currentUserId}`);
           window.location.href = `/seat.html?userId=${currentUserId}`;
         }

--- a/src/main/resources/static/seat.html
+++ b/src/main/resources/static/seat.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>좌석 선택</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+        }
+
+        .seat-container {
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
+            gap: 10px;
+            max-width: 300px;
+            margin: 20px auto;
+        }
+
+        .seat {
+            width: 50px;
+            height: 50px;
+            border: 1px solid #007AFF;
+            background-color: #E0E0E0;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
+        .seat.selected {
+            background-color: #007AFF;
+            color: white;
+        }
+
+        .controls {
+            margin-top: 20px;
+        }
+
+        button {
+            padding: 10px 20px;
+            border: none;
+            background-color: #007AFF;
+            color: white;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+
+        button:disabled {
+            background-color: #CCCCCC;
+            cursor: not-allowed;
+        }
+    </style>
+</head>
+<body>
+<h1>좌석 선택</h1>
+<div class="seat-container" id="seatContainer"></div>
+<div class="controls">
+    <button id="confirmButton" disabled>확인</button>
+</div>
+
+<script>
+    const totalSeats = 10; // 총 좌석 수
+    let selectedSeat = null;
+
+    // URL에서 userId 가져오기
+    const urlParams = new URLSearchParams(window.location.search);
+    const userId = urlParams.get('userId');
+
+    if (!userId) {
+        alert('잘못된 접근입니다.');
+        window.location.href = '/';
+    }
+
+    const seatContainer = document.getElementById('seatContainer');
+    const confirmButton = document.getElementById('confirmButton');
+
+    // 좌석 생성
+    for (let i = 1; i <= totalSeats; i++) {
+        const seat = document.createElement('div');
+        seat.classList.add('seat');
+        seat.textContent = i;
+        seat.dataset.seatNumber = i; // 좌석 번호 저장
+
+        // 좌석 클릭 이벤트
+        seat.addEventListener('click', () => selectSeat(seat, i));
+        seatContainer.appendChild(seat);
+    }
+
+    // 좌석 선택
+    function selectSeat(seat, seatNumber) {
+        if (selectedSeat) {
+            selectedSeat.classList.remove('selected');
+        }
+        seat.classList.add('selected');
+        selectedSeat = seat;
+
+        confirmButton.disabled = false;
+        confirmButton.dataset.seatNumber = seatNumber; // 선택된 좌석 번호 저장
+    }
+
+    // 좌석 예약 요청
+    confirmButton.addEventListener('click', () => {
+        const seatNumber = confirmButton.dataset.seatNumber;
+        fetch(`http://localhost:8080/ticket/${seatNumber}/reserve?userId=${userId}`, {
+            method: 'POST',
+        })
+            .then(response => {
+                if (response.ok) {
+                    alert(`좌석 ${seatNumber}번 예약 완료!`);
+                    window.location.href = '/';
+                } else {
+                    return response.text().then(err => {
+                        alert(`예약 실패: ${err}`);
+                    });
+                }
+            })
+            .catch(err => {
+                console.error('예약 요청 중 오류 발생:', err);
+                alert('예약 요청 중 오류가 발생했습니다.');
+            });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
feat
- 토큰 검사는 절대로 못할 것 같아서 (2000명 토큰 어떻게 해야함..), userId 입력받는 걸로 수정
- `index.html` : 좌석 지정 전 예매 화면
- `seat.html` : 좌석 예매 화면, 일단 10자리로 하드코딩
- 티켓 수만큼 사람 대기 없이 입장, 티켓수+1명부터는 대기 시작 (일단 시뮬레이션을 위해 3명까지 대기 없는 걸로 하드코딩)
- `redis/websocket `사용해서 실시간으로 대기번호 알려주고, 내 차례 다가왔을 때 바로 seat.html 로 화면 이동

진짜 또라이될뻔했지만.. 암튼 지금은..성공(?)

https://github.com/user-attachments/assets/1e4fc9ad-2b86-4b61-a2c8-0c1f9f51d677

